### PR TITLE
fix Issue with RDF output

### DIFF
--- a/docs/source/_calculators/experimental_calculators.rst
+++ b/docs/source/_calculators/experimental_calculators.rst
@@ -18,7 +18,7 @@ Angular Distribution Functions
 In the case of the Angular distribution functions the same comments as for the RDF apply but with some additional
 points.
 
-    * Use `tf_function=True` can result in memory overload and we do not have a means to prevent this.
+    * Use of `tf_function=True` can result in memory overload and we do not have a means to prevent this.
     * The normalization factor is not yet added. This mean bonds at any distance up to the cutoff are treated equally.
 
 Distinct Diffusion Coefficients

--- a/docs/source/_calculators/experimental_calculators.rst
+++ b/docs/source/_calculators/experimental_calculators.rst
@@ -18,7 +18,7 @@ Angular Distribution Functions
 In the case of the Angular distribution functions the same comments as for the RDF apply but with some additional
 points.
 
-    * Use tf_function=True can result in memory overload and we do not have a means to prevent this.
+    * Use `tf_function=True` can result in memory overload and we do not have a means to prevent this.
     * The normalization factor is not yet added. This mean bonds at any distance up to the cutoff are treated equally.
 
 Distinct Diffusion Coefficients

--- a/docs/source/_user_guide/molten_salt_example.ipynb
+++ b/docs/source/_user_guide/molten_salt_example.ipynb
@@ -1244,7 +1244,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the case of series data one might want to convert them into an numpy array which can easily be done with `obj.data_array()` wich gives an array of the shape `(length, 4)` where each element consists of the 4 attributes `x, y, z, uncertainty`. They are set to `None` if not available"
+    "For the case of series data one might want to convert them into a numpy array which can easily be done with `obj.data_array()` which gives an array of the shape `(length, 4)` where each element consists of the 4 attributes `x, y, z, uncertainty`. They are set to `None` if not available"
    ]
   },
   {

--- a/mdsuite/calculators/radial_distribution_function.py
+++ b/mdsuite/calculators/radial_distribution_function.py
@@ -629,8 +629,8 @@ class RadialDistributionFunction(Calculator, ABC):
             self.mini_calculate_histograms()
 
         self._calculate_radial_distribution_functions()
-
-        return self.rdf
+        # Can not return a value, because self.experimental = True!
+        # return self.rdf
 
     def get_partial_triu_indices(self, n_atoms: int, m_atoms: int, idx: int) -> tf.Tensor:
         """Calculate the indices of a slice of the triu values

--- a/mdsuite/utils/meta_functions.py
+++ b/mdsuite/utils/meta_functions.py
@@ -17,6 +17,8 @@ This file contains arbitrary functions used in several different processes. They
 smaller purposes in order to clean up code in more important parts of the program.
 """
 
+import logging
+
 import os
 from functools import wraps
 from time import time
@@ -29,6 +31,8 @@ from scipy.signal import savgol_filter
 
 from mdsuite.utils.exceptions import NoGPUInSystem
 from mdsuite.utils.units import golden_ratio
+
+log = logging.getLogger(__file__)
 
 
 def join_path(a, b):
@@ -108,7 +112,7 @@ def get_machine_properties() -> dict:
             machine_properties['gpu'][gpu.id]['name'] = gpu.name
             machine_properties['gpu'][gpu.id]['memory'] = gpu.memoryTotal
     except (NoGPUInSystem, ValueError):
-        raise NoGPUInSystem
+        log.warning("No GPUs detected, continuing without GPU support")
 
     return machine_properties
 

--- a/mdsuite/utils/meta_functions.py
+++ b/mdsuite/utils/meta_functions.py
@@ -107,7 +107,7 @@ def get_machine_properties() -> dict:
             machine_properties['gpu'][gpu.id]= {}
             machine_properties['gpu'][gpu.id]['name'] = gpu.name
             machine_properties['gpu'][gpu.id]['memory'] = gpu.memoryTotal
-    except NoGPUInSystem:
+    except (NoGPUInSystem, ValueError):
         raise NoGPUInSystem
 
     return machine_properties


### PR DESCRIPTION
To solve #210 I added a return value to the RDF. Because RDF is set to be experimental, it now always returns the rdf dict which is bad for running it in Jupyter. I removed the return statement. I also changed the `get_machine_properties` because it raised a `ValueError` on Google Colab. I think, that changing the `raise Error` to a `log.warning` should solve that. It seems to work, but I don't know if it comes with other issues?