### PR TITLE
catch empty sim data file

### DIFF
--- a/mdsuite/experiment/experiment.py
+++ b/mdsuite/experiment/experiment.py
@@ -800,6 +800,8 @@ class Experiment:
             with open(self.simulation_data_file) as f:
                 log.debug("Load simulation data from yaml file")
                 simulation_data = yaml.safe_load(f)
+                if simulation_data is None:
+                    simulation_data = dict()
         except FileNotFoundError:
             simulation_data = {}
         simulation_data.update(value)


### PR DESCRIPTION
an empty sim data file can occur if the dict passed in the setter cannot be written (e.g. it contains an ``np.array``).
