### PR TITLE
avoid bokeh having scroll bars

### DIFF
--- a/mdsuite/utils/config.py
+++ b/mdsuite/utils/config.py
@@ -49,3 +49,7 @@ try:
     config.jupyter = get_ipython().__class__.__name__ == "ZMQInteractiveShell"
 except NameError:
     pass
+
+if config.jupyter:
+    # change default in Jupyter Notebooks
+    config.bokeh_sizing_mode = None

--- a/mdsuite/utils/config.py
+++ b/mdsuite/utils/config.py
@@ -29,10 +29,18 @@ from dataclasses import dataclass
 
 @dataclass
 class Config:
-    """Collection of MDSuite configurations"""
+    """Collection of MDSuite configurations
+
+    Attributes
+    -----------
+    bokeh_sizing_mode: str
+        The way bokeh scales plots.
+        see bokeh / sizing_mode for more information
+    """
 
     jupyter: bool = False
     GPU: bool = False
+    bokeh_sizing_mode: str = "scale_both"
 
 
 config = Config()

--- a/mdsuite/visualizer/d2_data_visualization.py
+++ b/mdsuite/visualizer/d2_data_visualization.py
@@ -81,7 +81,9 @@ class DataVisualizer2D:
         figure : figure
                 A bokeh figure object.
         """
-        fig = figure(x_axis_label=x_label, y_axis_label=y_label, sizing_mode="stretch_both")
+        fig = figure(
+            x_axis_label=x_label, y_axis_label=y_label, sizing_mode="stretch_both"
+        )
         fig.line(x_data, y_data, legend_label=title)
         fig.add_tools(HoverTool())
         if layouts is not None:

--- a/mdsuite/visualizer/d2_data_visualization.py
+++ b/mdsuite/visualizer/d2_data_visualization.py
@@ -82,7 +82,9 @@ class DataVisualizer2D:
                 A bokeh figure object.
         """
         fig = figure(
-            x_axis_label=x_label, y_axis_label=y_label, sizing_mode="stretch_both"
+            x_axis_label=x_label,
+            y_axis_label=y_label,
+            sizing_mode=config.bokeh_sizing_mode,
         )
         fig.line(x_data, y_data, legend_label=title)
         fig.add_tools(HoverTool())

--- a/mdsuite/visualizer/d2_data_visualization.py
+++ b/mdsuite/visualizer/d2_data_visualization.py
@@ -82,7 +82,9 @@ class DataVisualizer2D:
                 A bokeh figure object.
         """
         fig = figure(
-            x_axis_label=x_label, y_axis_label=y_label, sizing_mode="stretch_both"
+            x_axis_label=x_label,
+            y_axis_label=y_label,
+            sizing_mode=config.bokeh_sizing_mode,
         )
         fig.line(x_data, y_data, legend_label=title)
         fig.add_tools(HoverTool())
@@ -105,5 +107,5 @@ class DataVisualizer2D:
         -------
 
         """
-        grid = gridplot(figures, ncols=3, sizing_mode="scale_both")
+        grid = gridplot(figures, ncols=3, sizing_mode="stretch_both")
         show(grid)

--- a/mdsuite/visualizer/d2_data_visualization.py
+++ b/mdsuite/visualizer/d2_data_visualization.py
@@ -81,7 +81,7 @@ class DataVisualizer2D:
         figure : figure
                 A bokeh figure object.
         """
-        fig = figure(x_axis_label=x_label, y_axis_label=y_label, sizing_mode='stretch_both')
+        fig = figure(x_axis_label=x_label, y_axis_label=y_label, sizing_mode="stretch_both")
         fig.line(x_data, y_data, legend_label=title)
         fig.add_tools(HoverTool())
         if layouts is not None:

--- a/mdsuite/visualizer/d2_data_visualization.py
+++ b/mdsuite/visualizer/d2_data_visualization.py
@@ -81,7 +81,7 @@ class DataVisualizer2D:
         figure : figure
                 A bokeh figure object.
         """
-        fig = figure(x_axis_label=x_label, y_axis_label=y_label)
+        fig = figure(x_axis_label=x_label, y_axis_label=y_label, sizing_mode='stretch_both')
         fig.line(x_data, y_data, legend_label=title)
         fig.add_tools(HoverTool())
         if layouts is not None:


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
I am not sure if this also fixes #375 
However, every time I was visualizing with Bokeh, Chrome had vertical scrolling and it was quite annoying. 
Adding `sizing_mode='stretch_both'` adapts it to the screen size. 

Very small PR, but otherwise I will forget about it. 
