### PR TITLE
Bypass generator minibatching in RDF/ADF calculator.

### DIFF
--- a/mdsuite/calculators/angular_distribution_function.py
+++ b/mdsuite/calculators/angular_distribution_function.py
@@ -215,7 +215,9 @@ class AngularDistributionFunction(TrajectoryCalculator, ABC):
         self.gpu = gpu
         self.plot = plot
         self._batch_size = batch_size  # memory management for all batches
-        self.adf_minibatch = minibatch  # memory management for triples generation per batch.
+        self.adf_minibatch = (
+            minibatch  # memory management for triples generation per batch.
+        )
         self.bin_range = [0.0, 3.15]  # from 0 to a chemists pi
         self.norm_power = norm_power
         self.override_n_batches = kwargs.get("batches")

--- a/mdsuite/calculators/angular_distribution_function.py
+++ b/mdsuite/calculators/angular_distribution_function.py
@@ -134,7 +134,7 @@ class AngularDistributionFunction(TrajectoryCalculator, ABC):
         self.result_series_keys = ["angle", "adf"]
         self._dtype = tf.float32
 
-        self.minibatch = None  # memory management for triples generation per batch.
+        self.adf_minibatch = None  # memory management for triples generation per batch.
 
         self.analysis_name = "Angular_Distribution_Function"
         self.x_label = r"$$\text{Angle} / \theta $$"
@@ -215,7 +215,7 @@ class AngularDistributionFunction(TrajectoryCalculator, ABC):
         self.gpu = gpu
         self.plot = plot
         self._batch_size = batch_size  # memory management for all batches
-        self.minibatch = minibatch  # memory management for triples generation per batch.
+        self.adf_minibatch = minibatch  # memory management for triples generation per batch.
         self.bin_range = [0.0, 3.15]  # from 0 to a chemists pi
         self.norm_power = norm_power
         self.override_n_batches = kwargs.get("batches")
@@ -302,7 +302,7 @@ class AngularDistributionFunction(TrajectoryCalculator, ABC):
                     x,
                     r_cut=self.cutoff,
                     n_atoms=self.number_of_atoms,
-                    n_batches=self.minibatch,
+                    n_batches=self.adf_minibatch,
                     disable_tqdm=True,
                 )
 
@@ -313,7 +313,7 @@ class AngularDistributionFunction(TrajectoryCalculator, ABC):
                     x,
                     r_cut=self.cutoff,
                     n_atoms=self.number_of_atoms,
-                    n_batches=self.minibatch,
+                    n_batches=self.adf_minibatch,
                     disable_tqdm=True,
                 )
 
@@ -521,6 +521,15 @@ class AngularDistributionFunction(TrajectoryCalculator, ABC):
 
         if self.override_n_batches is not None:
             self.n_batches = self.override_n_batches
+
+        if self.minibatch:
+            self.batch_size = 1
+            self.n_batches = self.args.number_of_configurations
+            self.remainder = 0
+            self.memory_manager.atom_batch_size = None
+            self.memory_manager.n_atom_batches = None
+            self.memory_manager.atom_remainder = None
+            self.minibatch = False
 
     def prepare_computation(self):
         """

--- a/mdsuite/calculators/radial_distribution_function.py
+++ b/mdsuite/calculators/radial_distribution_function.py
@@ -128,7 +128,7 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
 
         self._dtype = tf.float32
 
-        self.minibatch = None
+        self.rdf_minibatch = None
         self.use_tf_function = None
         self.override_n_batches = None
         self.index_list = None
@@ -207,7 +207,7 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
         )
         # args parsing that will not affect the computation result
         # usually performance or plotting
-        self.minibatch = minibatch
+        self.rdf_minibatch = minibatch
         self.plot = plot
         self.gpu = gpu
 
@@ -237,8 +237,8 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
                 self.experiment.number_of_configurations - 1
             )
 
-        if self.minibatch == -1:
-            self.minibatch = self.args.number_of_configurations
+        if self.rdf_minibatch == -1:
+            self.rdf_minibatch = self.args.number_of_configurations
 
         if self.args.number_of_bins is None:
             self.args.number_of_bins = int(
@@ -415,6 +415,15 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
 
         if self.override_n_batches is not None:
             self.n_batches = self.override_n_batches
+
+        if self.minibatch:
+            self.batch_size = 1
+            self.n_batches = self.args.number_of_configurations
+            self.remainder = 0
+            self.memory_manager.atom_batch_size = None
+            self.memory_manager.n_atom_batches = None
+            self.memory_manager.atom_remainder = None
+            self.minibatch = False
 
     def run_minibatch_loop(self, atoms, stop, n_atoms, minibatch_start, positions_tensor):
         """
@@ -838,7 +847,6 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
 
         # Loop over the batches.
         for idx, batch in tqdm(enumerate(batch_ds), ncols=70, disable=batch_tqm):
-
             # Reformat the data.
             log.debug("Reformatting data.")
             positions_tensor = self._format_data(batch=batch, keys=dict_keys)
@@ -858,7 +866,7 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
             }
 
             for atoms in tqdm(
-                per_atoms_ds.batch(self.minibatch).prefetch(tf.data.AUTOTUNE),
+                per_atoms_ds.batch(self.rdf_minibatch).prefetch(tf.data.AUTOTUNE),
                 ncols=70,
                 disable=not batch_tqm,
                 desc=f"Running mini batch loop {idx + 1} / {self.n_batches}",

--- a/mdsuite/calculators/trajectory_calculator.py
+++ b/mdsuite/calculators/trajectory_calculator.py
@@ -255,10 +255,11 @@ class TrajectoryCalculator(Calculator, ABC):
             self.remainder,
         ) = self.memory_manager.get_batch_size(system=self.system_property)
 
-        self.ensemble_loop, minibatch = self.memory_manager.get_ensemble_loop(
+        self.ensemble_loop, self.minibatch = self.memory_manager.get_ensemble_loop(
             self.args.data_range, self.args.correlation_time
         )
-        if minibatch:
+
+        if self.minibatch:
             self.batch_size = self.memory_manager.batch_size
             self.n_batches = self.memory_manager.n_batches
             self.remainder = self.memory_manager.remainder
@@ -276,7 +277,7 @@ class TrajectoryCalculator(Calculator, ABC):
             correlation_time=self.args.correlation_time,
             remainder=self.remainder,
             atom_selection=self.args.atom_selection,
-            minibatch=minibatch,
+            minibatch=self.minibatch,
             atom_batch_size=self.memory_manager.atom_batch_size,
             n_atom_batches=self.memory_manager.n_atom_batches,
             atom_remainder=self.memory_manager.atom_remainder,


### PR DESCRIPTION
Forcefully bypass the generator mini batching for RDF and ADF as it is built into the calculator itself. This resolves issues that can arise when mini batching is triggered on these calculators. Not sure yet whether this will solve the random test failures.
