### PR TITLE
Adapt scaling factors to get test runs to work.

### DIFF
--- a/mdsuite/calculators/angular_distribution_function.py
+++ b/mdsuite/calculators/angular_distribution_function.py
@@ -122,7 +122,9 @@ class AngularDistributionFunction(TrajectoryCalculator, ABC):
                 Experiment object from which to take attributes.
         """
         super().__init__(**kwargs)
-        self.scale_function = {"quadratic": {"outer_scale_factor": 10}}
+        self.scale_function = {
+            "quadratic": {"outer_scale_factor": 10, "inner_scale_factor": 5}
+        }
         self.loaded_property = mdsuite_properties.positions
 
         self.use_tf_function = None

--- a/mdsuite/calculators/einstein_distinct_diffusion_coefficients.py
+++ b/mdsuite/calculators/einstein_distinct_diffusion_coefficients.py
@@ -99,7 +99,7 @@ class EinsteinDistinctDiffusionCoefficients(TrajectoryCalculator):
         """
         super().__init__(**kwargs)
 
-        self.scale_function = {"linear": {"scale_factor": 10}}
+        self.scale_function = {"quadratic": {"inner_scale_factor": 5}}
         self.loaded_property = mdsuite_properties.unwrapped_positions
 
         self.database_group = "Diffusion_Coefficients"

--- a/mdsuite/calculators/green_kubo_distinct_diffusion_coefficients.py
+++ b/mdsuite/calculators/green_kubo_distinct_diffusion_coefficients.py
@@ -93,7 +93,7 @@ class GreenKuboDistinctDiffusionCoefficients(TrajectoryCalculator, ABC):
         """
         super().__init__(**kwargs)
 
-        self.scale_function = {"linear": {"scale_factor": 5}}
+        self.scale_function = {"quadratic": {"inner_scale_factor": 5}}
         self.loaded_property = mdsuite_properties.velocities
 
         self.database_group = "Diffusion_Coefficients"

--- a/mdsuite/calculators/radial_distribution_function.py
+++ b/mdsuite/calculators/radial_distribution_function.py
@@ -119,7 +119,9 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
         """
         super().__init__(**kwargs)
 
-        self.scale_function = {"quadratic": {"outer_scale_factor": 1}}
+        self.scale_function = {
+            "quadratic": {"outer_scale_factor": 10, "inner_scale_function": 5}
+        }
         self.loaded_property = mdsuite_properties.positions
         self.x_label = r"$$r / nm$$"
         self.y_label = r"$$g(r)$$"

--- a/mdsuite/calculators/radial_distribution_function.py
+++ b/mdsuite/calculators/radial_distribution_function.py
@@ -120,7 +120,7 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
         super().__init__(**kwargs)
 
         self.scale_function = {
-            "quadratic": {"outer_scale_factor": 10, "inner_scale_function": 5}
+            "quadratic": {"outer_scale_factor": 10, "inner_scale_factor": 5}
         }
         self.loaded_property = mdsuite_properties.positions
         self.x_label = r"$$r / nm$$"


### PR DESCRIPTION
Adapted the scaling factors of some memory intensive computations as some example runs failed when deployed on 4GB GPU.

Related to #464 we should have some scaling default for a 4GB or even smaller memory usage to ensure the scaling function parameters are fit correctly.