### PR TITLE
compute volume from box array (not cached)

### DIFF
--- a/mdsuite/database/experiment_database.py
+++ b/mdsuite/database/experiment_database.py
@@ -83,7 +83,6 @@ class ExperimentDatabase:
     number_of_configurations = LazyProperty()
     number_of_atoms = LazyProperty()
     sample_rate = LazyProperty()
-    volume = LazyProperty()
     property_groups = LazyProperty()
 
     def __init__(self, project: Project, experiment_name):
@@ -393,3 +392,9 @@ class ExperimentDatabase:
         if value is None:
             return
         self.set_db(name="version", value=value)
+
+    # On the fly properties
+    @property
+    def volume(self):
+        """Compute the Volume"""
+        return np.prod(self.box_array)

--- a/mdsuite/experiment/experiment.py
+++ b/mdsuite/experiment/experiment.py
@@ -197,7 +197,6 @@ class Experiment(ExperimentDatabase):
         self.sample_rate = (
             None  # Rate at which configurations are dumped in the trajectory.
         )
-        self.volume = None
         self.properties = None  # Properties measured in the simulation.
         self.property_groups = None  # Names of the properties measured in the simulation
 
@@ -618,7 +617,6 @@ class Experiment(ExperimentDatabase):
             )
         else:
             self.dimensions = None
-        self.volume = np.prod(self.box_array)
         # todo look into replacing these properties
         self.sample_rate = metadata.sample_rate
         species_list = copy.deepcopy(metadata.species_list)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #499 

The volume is computed on the fly each time via `np.prod(box_array)`

We could add https://docs.python.org/3/library/functools.html#functools.cached_property but if the box_array changes this causes issues. Computing the product of 3 values is probably so fast, that any if/else cache is not required.