### PR TITLE
lammpstraj: catch empty header for traj with only one time step

### DIFF
--- a/mdsuite/file_io/lammps_trajectory_files.py
+++ b/mdsuite/file_io/lammps_trajectory_files.py
@@ -229,7 +229,7 @@ class LAMMPSTrajectoryFile(mdsuite.file_io.tabular_text_files.TabularTextFilePro
 
         return species_dict
 
-    def _get_sample_rate(self, file, n_particles: int) -> int:
+    def _get_sample_rate(self, file, n_particles: int) -> typing.Union[int, None]:
         first_header = mdsuite.file_io.tabular_text_files.read_n_lines(
             file, self.n_header_lines, start_at=0
         )
@@ -237,8 +237,11 @@ class LAMMPSTrajectoryFile(mdsuite.file_io.tabular_text_files.TabularTextFilePro
         second_header = mdsuite.file_io.tabular_text_files.read_n_lines(
             file, self.n_header_lines, start_at=self.n_header_lines + n_particles
         )
-        time__step_1 = int(second_header[1])  # Time in second configuration
+        # catch single snapshot trajectory (second_header == [])
+        if not second_header:
+            return None
 
+        time__step_1 = int(second_header[1])  # Time in second configuration
         return time__step_1 - time_step_0
 
 

--- a/mdsuite/file_io/lammps_trajectory_files.py
+++ b/mdsuite/file_io/lammps_trajectory_files.py
@@ -270,7 +270,7 @@ def extract_properties_from_header(
     trajectory_properties : dict
         A dict of the form
         {'MDSuite_Property_1': [column_indices], 'MDSuite_Property_2': ...}
-        Example {'Unwrapped_Positions': [2,3,4], 'Velocities': [5,6,7]}
+        Example {'Unwrapped_Positions': [2,3,4], 'Velocities': [5,6,8]}
     """
 
     column_dict_properties = {


### PR DESCRIPTION
fix #379 for lammps
the other readers were able to handle single snapshots before.

~Test fail because of #510~
