### PR TITLE
add `tag` to `zinchub.DataHub`

### DIFF
--- a/CI/functional_tests/test_molten_salts.py
+++ b/CI/functional_tests/test_molten_salts.py
@@ -38,11 +38,15 @@ def traj_files(tmp_path_factory) -> Tuple[str, str]:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl_file = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_rnd_md")
+    NaCl_file = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_rnd_md", tag="v0.1.0"
+    )
     NaCl_file.get_file(temporary_path)
     NaCl_out = (temporary_path / NaCl_file.file_raw).as_posix()
 
-    KCl_file = DataHub(url="https://github.com/zincware/DataHub/tree/main/KCl_rnd_md")
+    KCl_file = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/KCl_rnd_md", tag="v0.1.0"
+    )
     KCl_file.get_file(temporary_path)
     KCl_out = (temporary_path / KCl_file.get_file(temporary_path)).as_posix()
 

--- a/CI/functional_tests/test_water_study.py
+++ b/CI/functional_tests/test_water_study.py
@@ -40,7 +40,9 @@ def traj_files(tmp_path_factory) -> List[str]:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    water = DataHub(url="https://github.com/zincware/DataHub/tree/main/Water_14_Gromacs")
+    water = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/Water_14_Gromacs", tag="v0.1.0"
+    )
     water.get_file(temporary_path)
     file_paths = [(temporary_path / f).as_posix() for f in water.file_raw]
     return file_paths

--- a/CI/integration_tests/calculators/__test_structure_factor.py
+++ b/CI/integration_tests/calculators/__test_structure_factor.py
@@ -40,7 +40,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -49,7 +51,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="StructureFactor.json")
 
 

--- a/CI/integration_tests/calculators/_test_coordination_numbers.py
+++ b/CI/integration_tests/calculators/_test_coordination_numbers.py
@@ -38,7 +38,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -47,7 +49,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="CoordinationNumbers.json")
 
 

--- a/CI/integration_tests/calculators/_test_einstein_helfand_thermal_kinaci.py
+++ b/CI/integration_tests/calculators/_test_einstein_helfand_thermal_kinaci.py
@@ -41,7 +41,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -50,7 +52,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="EinsteinHelfandThermanKinaci.json")
 
 

--- a/CI/integration_tests/calculators/_test_green_kubo_thermal_conductivity.py
+++ b/CI/integration_tests/calculators/_test_green_kubo_thermal_conductivity.py
@@ -40,7 +40,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -49,7 +51,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="GreenKuboThermalConductivity.json")
 
 

--- a/CI/integration_tests/calculators/_test_green_kubo_viscosity.py
+++ b/CI/integration_tests/calculators/_test_green_kubo_viscosity.py
@@ -40,7 +40,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -49,7 +51,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="GreenKuboViscosity.json")
 
 

--- a/CI/integration_tests/calculators/_test_green_kubo_viscosity_flux.py
+++ b/CI/integration_tests/calculators/_test_green_kubo_viscosity_flux.py
@@ -41,7 +41,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -50,7 +52,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="GreenKuboViscosityFlux.json")
 
 

--- a/CI/integration_tests/calculators/_test_nernst_einstein_ionic_conductivity.py
+++ b/CI/integration_tests/calculators/_test_nernst_einstein_ionic_conductivity.py
@@ -40,7 +40,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -49,7 +51,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="NernstEinsteinIonicConductivity.json")
 
 

--- a/CI/integration_tests/calculators/test_angular_distribution_function.py
+++ b/CI/integration_tests/calculators/test_angular_distribution_function.py
@@ -38,7 +38,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -47,7 +49,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="AngularDistributionFunction.json")
 
 

--- a/CI/integration_tests/calculators/test_einstein_diffusion_coefficients.py
+++ b/CI/integration_tests/calculators/test_einstein_diffusion_coefficients.py
@@ -38,7 +38,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -47,7 +49,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="EinsteinDiffusionCoefficients.json")
 
 

--- a/CI/integration_tests/calculators/test_einstein_distinct_diffusion_coefficients.py
+++ b/CI/integration_tests/calculators/test_einstein_distinct_diffusion_coefficients.py
@@ -43,7 +43,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -52,7 +54,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="RadialDistributionFunction.json")
 
 

--- a/CI/integration_tests/calculators/test_einstein_helfand_ionic_conductivity.py
+++ b/CI/integration_tests/calculators/test_einstein_helfand_ionic_conductivity.py
@@ -37,7 +37,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -46,7 +48,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="EinsteinHelfandIonicConductivity.json")
 
 

--- a/CI/integration_tests/calculators/test_green_kubo_distinct_diffusion_coefficients.py
+++ b/CI/integration_tests/calculators/test_green_kubo_distinct_diffusion_coefficients.py
@@ -37,7 +37,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -46,7 +48,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="RadialDistributionFunction.json")
 
 

--- a/CI/integration_tests/calculators/test_green_kubo_ionic_conductivity.py
+++ b/CI/integration_tests/calculators/test_green_kubo_ionic_conductivity.py
@@ -38,7 +38,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -47,7 +49,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="GreenKuboIonicConductivity.json")
 
 

--- a/CI/integration_tests/calculators/test_kirkwood_buff_integrals.py
+++ b/CI/integration_tests/calculators/test_kirkwood_buff_integrals.py
@@ -24,12 +24,13 @@ If you use this module please cite us with:
 Summary
 -------
 """
+import os
+
 import pytest
 from zinchub import DataHub
 
-# import os
-# import mdsuite as mds
-# from mdsuite.utils.testing import assertDeepAlmostEqual
+import mdsuite as mds
+from mdsuite.utils.testing import assertDeepAlmostEqual
 
 
 @pytest.fixture(scope="session")
@@ -54,14 +55,14 @@ def true_values() -> dict:
     return NaCl.get_analysis(analysis="KirkwoodBuffIntegral.json")
 
 
-# def test_project(traj_file, true_values, tmp_path):
-#     """Test the kbi called from the project class"""
-#     os.chdir(tmp_path)
-#     project = mds.Project()
-#     project.add_experiment(
-#         "NaCl", simulation_data=traj_file, timestep=0.002, temperature=1400
-#     )
-#
-#     computation = project.run.KirkwoodBuffIntegral(plot=False)
-#
-#     assertDeepAlmostEqual(computation["NaCl"].data_dict, true_values, decimal=1)
+def test_project(traj_file, true_values, tmp_path):
+    """Test the kbi called from the project class"""
+    os.chdir(tmp_path)
+    project = mds.Project()
+    project.add_experiment(
+        "NaCl", simulation_data=traj_file, timestep=0.002, temperature=1400
+    )
+
+    computation = project.run.KirkwoodBuffIntegral(plot=False)
+
+    assertDeepAlmostEqual(computation["NaCl"].data_dict, true_values, decimal=1)

--- a/CI/integration_tests/calculators/test_kirkwood_buff_integrals.py
+++ b/CI/integration_tests/calculators/test_kirkwood_buff_integrals.py
@@ -37,7 +37,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -46,7 +48,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="KirkwoodBuffIntegral.json")
 
 

--- a/CI/integration_tests/calculators/test_potential_of_mean_force.py
+++ b/CI/integration_tests/calculators/test_potential_of_mean_force.py
@@ -24,13 +24,13 @@ If you use this module please cite us with:
 Summary
 -------
 """
-# import os
+import os
 
 import pytest
 from zinchub import DataHub
 
-# import mdsuite as mds
-# from mdsuite.utils.testing import assertDeepAlmostEqual
+import mdsuite as mds
+from mdsuite.utils.testing import assertDeepAlmostEqual
 
 
 @pytest.fixture(scope="session")
@@ -55,27 +55,27 @@ def true_values() -> dict:
     return NaCl.get_analysis(analysis="PotentialOfMeanForce.json")
 
 
-# def test_project(traj_file, true_values, tmp_path):
-#     """Test the pomf called from the project class"""
-#     os.chdir(tmp_path)
-#     project = mds.Project()
-#     project.add_experiment(
-#         "NaCl", simulation_data=traj_file, timestep=0.002, temperature=1400
-#     )
-#
-#     computation = project.run.PotentialOfMeanForce(plot=False)
-#
-#     assertDeepAlmostEqual(computation["NaCl"].data_dict, true_values, decimal=-0)
-#
-#
-# def test_experiment(traj_file, true_values, tmp_path):
-#     """Test the pomf called from the experiment class"""
-#     os.chdir(tmp_path)
-#     project = mds.Project()
-#     project.add_experiment(
-#         "NaCl", simulation_data=traj_file, timestep=0.002, temperature=1400
-#     )
-#
-#     computation = project.experiments["NaCl"].run.PotentialOfMeanForce(plot=False)
-#
-#     assertDeepAlmostEqual(computation.data_dict, true_values, decimal=0)
+def test_project(traj_file, true_values, tmp_path):
+    """Test the pomf called from the project class"""
+    os.chdir(tmp_path)
+    project = mds.Project()
+    project.add_experiment(
+        "NaCl", simulation_data=traj_file, timestep=0.002, temperature=1400
+    )
+
+    computation = project.run.PotentialOfMeanForce(plot=False)
+
+    assertDeepAlmostEqual(computation["NaCl"].data_dict, true_values, decimal=-0)
+
+
+def test_experiment(traj_file, true_values, tmp_path):
+    """Test the pomf called from the experiment class"""
+    os.chdir(tmp_path)
+    project = mds.Project()
+    project.add_experiment(
+        "NaCl", simulation_data=traj_file, timestep=0.002, temperature=1400
+    )
+
+    computation = project.experiments["NaCl"].run.PotentialOfMeanForce(plot=False)
+
+    assertDeepAlmostEqual(computation.data_dict, true_values, decimal=0)

--- a/CI/integration_tests/calculators/test_potential_of_mean_force.py
+++ b/CI/integration_tests/calculators/test_potential_of_mean_force.py
@@ -38,7 +38,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -47,7 +49,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="PotentialOfMeanForce.json")
 
 

--- a/CI/integration_tests/calculators/test_radial_distribution_function.py
+++ b/CI/integration_tests/calculators/test_radial_distribution_function.py
@@ -38,7 +38,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()
@@ -47,7 +49,9 @@ def traj_file(tmp_path_factory) -> str:
 @pytest.fixture(scope="session")
 def true_values() -> dict:
     """Example fixture for downloading analysis results from github"""
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     return NaCl.get_analysis(analysis="RadialDistributionFunction.json")
 
 

--- a/CI/integration_tests/project/test_run_load_multiple_experiments.py
+++ b/CI/integration_tests/project/test_run_load_multiple_experiments.py
@@ -50,7 +50,7 @@ def traj_files(tmp_path_factory) -> list:
     for fname in files_to_load:
         folder = fname.split(".")[0]
         url = f"{base_url}/{folder}"
-        dhub_file = DataHub(url=url)
+        dhub_file = DataHub(url=url, tag="v0.1.0")
         dhub_file.get_file(temporary_path)
         file_paths.append((temporary_path / dhub_file.file_raw).as_posix())
 

--- a/CI/integration_tests/transformations/test_molecular_mapping_results.py
+++ b/CI/integration_tests/transformations/test_molecular_mapping_results.py
@@ -42,11 +42,15 @@ def traj_files(tmp_path_factory) -> Tuple[List[str], str]:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    water = DataHub(url="https://github.com/zincware/DataHub/tree/main/Water_14_Gromacs")
+    water = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/Water_14_Gromacs", tag="v0.1.0"
+    )
     water.get_file(temporary_path)
     file_paths = [(temporary_path / f).as_posix() for f in water.file_raw]
 
-    bmim_bf4 = DataHub(url="https://github.com/zincware/DataHub/tree/main/Bmim_BF4")
+    bmim_bf4 = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/Bmim_BF4", tag="v0.1.0"
+    )
     bmim_bf4.get_file(path=temporary_path)
 
     return file_paths, (temporary_path / bmim_bf4.file_raw).as_posix()

--- a/CI/integration_tests/transformations/test_transformation_run_options.py
+++ b/CI/integration_tests/transformations/test_transformation_run_options.py
@@ -21,7 +21,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()

--- a/CI/integration_tests/visualizer/znvis_visualizer.py
+++ b/CI/integration_tests/visualizer/znvis_visualizer.py
@@ -78,7 +78,9 @@ class TestZnvisVisualizer(unittest.TestCase):
         """
         temp_dir = tempfile.TemporaryDirectory()
         os.chdir(temp_dir.name)
-        argon = DataHub(url="https://github.com/zincware/DataHub/tree/main/Ar/Ar_dft")
+        argon = DataHub(
+            url="https://github.com/zincware/DataHub/tree/main/Ar/Ar_dft", tag="v0.1.0"
+        )
         argon.get_file(path=".")
         project = mds.Project("Ar_test")
         project.add_experiment(

--- a/CI/unit_tests/database/test_experiment_database.py
+++ b/CI/unit_tests/database/test_experiment_database.py
@@ -41,7 +41,9 @@ def traj_file(tmp_path_factory) -> str:
     """Download trajectory file into a temporary directory and keep it for all tests"""
     temporary_path = tmp_path_factory.getbasetemp()
 
-    NaCl = DataHub(url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q")
+    NaCl = DataHub(
+        url="https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q", tag="v0.1.0"
+    )
     NaCl.get_file(path=temporary_path)
 
     return (temporary_path / NaCl.file_raw).as_posix()

--- a/CI/unit_tests/project/test_project_add_experiment.py
+++ b/CI/unit_tests/project/test_project_add_experiment.py
@@ -102,8 +102,7 @@ def traj_files(tmp_path_factory) -> dict:
     for fname in files_to_load:
         folder = fname.split(".")[0]
         url = f"{base_url}/{folder}"
-        print(url)
-        dhub_file = DataHub(url=url)
+        dhub_file = DataHub(url=url, tag="v0.1.0")
         dhub_file.get_file(temporary_path)
         if isinstance(dhub_file.file_raw, list):
             file_paths[fname] = [

--- a/examples/notebooks/Mapping_Molecules.ipynb
+++ b/examples/notebooks/Mapping_Molecules.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "water = DataHub(url=\"https://github.com/zincware/DataHub/tree/main/Water_14_Gromacs\")\n",
+    "water = DataHub(url=\"https://github.com/zincware/DataHub/tree/main/Water_14_Gromacs\", tag=\"v0.1.0\")\n",
     "water.get_file('./')\n",
     "file_paths = [\n",
     "        f for f in water.file_raw\n",

--- a/examples/notebooks/Mapping_Molecules.ipynb
+++ b/examples/notebooks/Mapping_Molecules.ipynb
@@ -4229,7 +4229,7 @@
    "outputs": [],
    "source": [
     "bmim_bf4 = DataHub(\n",
-    "    url=\"https://github.com/zincware/DataHub/tree/main/Bmim_BF4\"\n",
+    "    url=\"https://github.com/zincware/DataHub/tree/main/Bmim_BF4\", tag=\"v0.1.0\"\n",
     ")\n",
     "bmim_bf4.get_file()\n",
     "bmim_file = bmim_bf4.file_raw"

--- a/examples/notebooks/NaCl_walkthrough.ipynb
+++ b/examples/notebooks/NaCl_walkthrough.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "NaCl = DataHub(url=\"https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q\")\n",
+    "NaCl = DataHub(url=\"https://github.com/zincware/DataHub/tree/main/NaCl_gk_i_q\", tag=\"v0.1.0\")\n",
     "NaCl.get_file(path=\".\")"
    ]
   },


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #510 

#### Summary of additions and changes

*  add `tag` to all `zinchub.DataHub` occurrences. 

We should probably activate the tests that were disabled in https://github.com/zincware/MDSuite/pull/508 again.