### PR TITLE
Restrict experiment names

### DIFF
--- a/CI/unit_tests/experiment/test_Experiment.py
+++ b/CI/unit_tests/experiment/test_Experiment.py
@@ -1,0 +1,8 @@
+import pytest
+
+from mdsuite.experiment.experiment import Experiment
+
+
+def test_experiment_name():
+    with pytest.raises(ValueError):
+        Experiment(experiment_name="250K", project=None)

--- a/CI/unit_tests/experiment/test_Experiment.py
+++ b/CI/unit_tests/experiment/test_Experiment.py
@@ -5,4 +5,4 @@ from mdsuite.experiment.experiment import Experiment
 
 def test_experiment_name():
     with pytest.raises(ValueError):
-        Experiment(experiment_name="250K", project=None)
+        Experiment(project=None, name="250K")

--- a/CI/unit_tests/project/test_project_add_experiment.py
+++ b/CI/unit_tests/project/test_project_add_experiment.py
@@ -190,14 +190,8 @@ def test_multiple_experiments(tmp_path):
 
     project_loaded = mds.Project()
 
-    assert (
-        project.experiments.Test01.experiment_path
-        == project_loaded.experiments.Test01.experiment_path
-    )
-    assert (
-        project.experiments.Test02.experiment_path
-        == project_loaded.experiments.Test02.experiment_path
-    )
+    assert project.experiments.Test01.path == project_loaded.experiments.Test01.path
+    assert project.experiments.Test02.path == project_loaded.experiments.Test02.path
 
 
 def test_lammps_read(traj_files, tmp_path):

--- a/mdsuite/database/experiment_database.py
+++ b/mdsuite/database/experiment_database.py
@@ -85,9 +85,9 @@ class ExperimentDatabase:
     sample_rate = LazyProperty()
     property_groups = LazyProperty()
 
-    def __init__(self, project: Project, experiment_name):
+    def __init__(self, project: Project, name):
         self.project = project
-        self.name = experiment_name
+        self.name = name
 
         # Property cache
         self._species = None

--- a/mdsuite/experiment/experiment.py
+++ b/mdsuite/experiment/experiment.py
@@ -136,7 +136,7 @@ class Experiment(ExperimentDatabase):
     def __init__(
         self,
         project,
-        experiment_name,
+        name,
         time_step=None,
         temperature=None,
         units: Union[str, Units] = None,
@@ -147,7 +147,7 @@ class Experiment(ExperimentDatabase):
 
         Attributes
         ----------
-        experiment_name : str
+        name : str
                 The name of the analysis being performed e.g. NaCl_1400K
         temperature : float
                 The temperature of the simulation that should be used in some analysis.
@@ -162,15 +162,14 @@ class Experiment(ExperimentDatabase):
                 computing cluster.
         """
 
-        if not experiment_name[0].isalpha():
+        if not name[0].isalpha():
             raise ValueError(
-                f"Experiment name must start with a letter! Found '{experiment_name[0]}'"
-                " instead."
+                f"Experiment name must start with a letter! Found '{name[0]}' instead."
             )
 
         # Taken upon instantiation
-        super().__init__(project=project, experiment_name=experiment_name)
-        self.name = experiment_name
+        super().__init__(project=project, name=name)
+        self.name = name
         self.storage_path = Path(project.storage_path, project.name).as_posix()
         self.cluster_mode = cluster_mode
 

--- a/mdsuite/experiment/experiment.py
+++ b/mdsuite/experiment/experiment.py
@@ -162,6 +162,12 @@ class Experiment(ExperimentDatabase):
                 computing cluster.
         """
 
+        if not experiment_name[0].isalpha():
+            raise ValueError(
+                f"Experiment name must start with a letter! Found '{experiment_name[0]}'"
+                " instead."
+            )
+
         # Taken upon instantiation
         super().__init__(project=project, experiment_name=experiment_name)
         self.name = experiment_name

--- a/mdsuite/experiment/experiment.py
+++ b/mdsuite/experiment/experiment.py
@@ -203,10 +203,9 @@ class Experiment(ExperimentDatabase):
         self.property_groups = None  # Names of the properties measured in the simulation
 
         # Internal File paths
-        self.experiment_path: Path
+        self.path: Path
         self.database_path: Path
         self.figures_path: Path
-        self.logfile_path: Path
         self._create_internal_file_paths()  # fill the path attributes
 
         # Check if the experiment exists and load if it does.
@@ -234,17 +233,21 @@ class Experiment(ExperimentDatabase):
         return f"exp_{self.name}"
 
     def _create_internal_file_paths(self):
+        """Create or update internal file paths
+
+        Attributes
+        -----------
+        path: Path
+            The default path for the experiment files
+        database_path: Path
+            Path to the database, by default equal to self.path
+        figures_path: Path
+            Path to the figures directory
+
         """
-        Create or update internal file paths
-        """
-        self.experiment_path = Path(
-            self.storage_path, self.name
-        )  # path to the experiment files
-        self.database_path = Path(self.experiment_path)  # path to the databases
-        self.figures_path = Path(
-            self.experiment_path, "figures"
-        )  # path to the figures directory
-        self.logfile_path = Path(self.experiment_path, "logfiles")
+        self.path = Path(self.storage_path, self.name)  # path to the experiment files
+        self.database_path = self.path  # path to the databases
+        self.figures_path = self.path / "figures"  # path to the figures directory
 
     def _build_model(self):
         """
@@ -259,10 +262,9 @@ class Experiment(ExperimentDatabase):
 
         # Create new analysis directory and change into it
         try:
-            self.experiment_path.mkdir()
+            self.path.mkdir()
             self.figures_path.mkdir()
             self.database_path.mkdir()
-            self.logfile_path.mkdir()
         except FileExistsError:  # throw exception if the file exits
             return
 
@@ -327,12 +329,13 @@ class Experiment(ExperimentDatabase):
         """
 
         # Check if the experiment exists and load if it does.
-        if Path(self.experiment_path).exists():
-            log.debug("This experiment already exists! I'll load it up now.")
-            # self.load_class()
+        if Path(self.path).exists():
+            log.debug(
+                f"This experiment ({self.name}) already exists! I'll load it up now."
+            )
             return True
         else:
-            log.info("Creating a new experiment!")
+            log.info(f"Creating a new experiment ({self.name})!")
             self._build_model()
             return False
 

--- a/mdsuite/project/project.py
+++ b/mdsuite/project/project.py
@@ -219,10 +219,10 @@ class Project(ProjectDatabase):
         # If the experiment does not exists, instantiate a new Experiment
         new_experiment = Experiment(
             project=self,
-            experiment_name=name,
+            name=name,
             time_step=timestep,
-            units=units,
             temperature=temperature,
+            units=units,
             cluster_mode=cluster_mode,
         )
 
@@ -319,9 +319,7 @@ class Project(ProjectDatabase):
         for exp in db_experiments:
             exp: db.Experiment
             if exp.name not in self._experiments:
-                self._experiments[exp.name] = Experiment(
-                    project=self, experiment_name=exp.name
-                )
+                self._experiments[exp.name] = Experiment(project=self, name=exp.name)
 
         return dotdict(self._experiments)
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #537 

# Summary
- restrict experiment names
- rename `Experiment.experiment_name` to `Experiment.name`
- rename `Experiment.experiment_path` to `Experiment.path`
- remove `Experiment.logfile_path`


# Open questions

What is the idea behind having dedicated database_path / figures_path? Currently database_path is set equal to path and I don't know if there are any tests that allow for changing it.