### PR TITLE
Sam tov fix memory scaling tests

### DIFF
--- a/CI/integration_tests/calculators/test_einstein_diffusion_coefficients.py
+++ b/CI/integration_tests/calculators/test_einstein_diffusion_coefficients.py
@@ -39,7 +39,6 @@ from mdsuite.database.simulation_database import (
     TrajectoryMetadata,
 )
 from mdsuite.file_io.script_input import ScriptInput
-mdsuite.config.memory_fraction = 0.0005
 
 
 def test_calculator(tmp_path):

--- a/CI/integration_tests/calculators/test_einstein_diffusion_coefficients.py
+++ b/CI/integration_tests/calculators/test_einstein_diffusion_coefficients.py
@@ -39,7 +39,7 @@ from mdsuite.database.simulation_database import (
     TrajectoryMetadata,
 )
 from mdsuite.file_io.script_input import ScriptInput
-mdsuite.config.memory_fraction = 1e-2
+
 
 def test_calculator(tmp_path):
     """
@@ -51,7 +51,7 @@ def test_calculator(tmp_path):
 
     n_part = 500
     n_step = 5000
-    msd_range = 500
+    msd_range = 200
 
     vel = np.sqrt(2 * diff_coeff / time_step) * tf.random.normal(
         shape=(n_step, n_part, 3), mean=0, stddev=1

--- a/CI/integration_tests/calculators/test_einstein_diffusion_coefficients.py
+++ b/CI/integration_tests/calculators/test_einstein_diffusion_coefficients.py
@@ -39,6 +39,7 @@ from mdsuite.database.simulation_database import (
     TrajectoryMetadata,
 )
 from mdsuite.file_io.script_input import ScriptInput
+mdsuite.config.memory_fraction = 0.0005
 
 
 def test_calculator(tmp_path):

--- a/CI/integration_tests/calculators/test_einstein_diffusion_coefficients.py
+++ b/CI/integration_tests/calculators/test_einstein_diffusion_coefficients.py
@@ -39,7 +39,7 @@ from mdsuite.database.simulation_database import (
     TrajectoryMetadata,
 )
 from mdsuite.file_io.script_input import ScriptInput
-
+mdsuite.config.memory_fraction = 1e-2
 
 def test_calculator(tmp_path):
     """

--- a/CI/integration_tests/calculators/test_radial_distribution_function.py
+++ b/CI/integration_tests/calculators/test_radial_distribution_function.py
@@ -32,7 +32,6 @@ from zinchub import DataHub
 import mdsuite
 import mdsuite as mds
 from mdsuite.utils.testing import assertDeepAlmostEqual
-mdsuite.config.memory_fraction = 1e-100
 
 
 @pytest.fixture(scope="session")

--- a/CI/integration_tests/calculators/test_radial_distribution_function.py
+++ b/CI/integration_tests/calculators/test_radial_distribution_function.py
@@ -29,7 +29,6 @@ import os
 import pytest
 from zinchub import DataHub
 
-import mdsuite
 import mdsuite as mds
 from mdsuite.utils.testing import assertDeepAlmostEqual
 

--- a/CI/integration_tests/calculators/test_radial_distribution_function.py
+++ b/CI/integration_tests/calculators/test_radial_distribution_function.py
@@ -29,8 +29,10 @@ import os
 import pytest
 from zinchub import DataHub
 
+import mdsuite
 import mdsuite as mds
 from mdsuite.utils.testing import assertDeepAlmostEqual
+mdsuite.config.memory_fraction = 1e-100
 
 
 @pytest.fixture(scope="session")

--- a/CI/unit_tests/memory_manager/test_memory_manager.py
+++ b/CI/unit_tests/memory_manager/test_memory_manager.py
@@ -148,9 +148,7 @@ class TestMemoryManager(unittest.TestCase):
         self.memory_manager.data_path = ["Test/Path"]
         self.memory_manager.memory_fraction = 0.5
         self.memory_manager.machine_properties["memory"] = 50000
-        batch_size, number_of_batches, remainder = self.memory_manager.get_batch_size(
-            system=False
-        )
+        batch_size, number_of_batches, remainder = self.memory_manager.get_batch_size()
         self.assertEqual(batch_size, 10)
         self.assertEqual(number_of_batches, 1)
         self.assertEqual(remainder, 0)
@@ -160,9 +158,7 @@ class TestMemoryManager(unittest.TestCase):
         self.memory_manager.data_path = ["Test/Path"]
         self.memory_manager.memory_fraction = 1.0
         self.memory_manager.machine_properties["memory"] = 50
-        batch_size, number_of_batches, remainder = self.memory_manager.get_batch_size(
-            system=False
-        )
+        batch_size, number_of_batches, remainder = self.memory_manager.get_batch_size()
         self.assertEqual(batch_size, 1)
         self.assertEqual(number_of_batches, 13)
         self.assertEqual(remainder, 0)

--- a/mdsuite/calculators/einstein_diffusion_coefficients.py
+++ b/mdsuite/calculators/einstein_diffusion_coefficients.py
@@ -245,8 +245,11 @@ class EinsteinDiffusionCoefficients(TrajectoryCalculator, ABC):
                 ensemble_ds = self.get_ensemble_dataset(batch, species)
 
                 for ensemble in ensemble_ds:
-                    self.msd_array += self.ensemble_operation(ensemble[dict_ref])
-                    self.count += 1
+                    if not ensemble[dict_ref].shape[1] == self.args.data_range:
+                        continue
+                    else:
+                        self.msd_array += self.ensemble_operation(ensemble[dict_ref])
+                        self.count += 1
 
             # self.msd_array = np.array(tf.reduce_sum(self.msd_array, axis=0))
             fit_results = self.fit_diff_coeff()

--- a/mdsuite/calculators/radial_distribution_function.py
+++ b/mdsuite/calculators/radial_distribution_function.py
@@ -250,7 +250,6 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
                 self.args.species = list(self.experiment.molecules)
             else:
                 self.args.species = list(self.experiment.species)
-
         self._initialize_rdf_parameters()
 
     def _initialize_rdf_parameters(self):
@@ -424,7 +423,6 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
             self.minibatch = False
 
         self.remainder = 0
-        self.minibatch = False
 
     def run_minibatch_loop(self, atoms, stop, n_atoms, minibatch_start, positions_tensor):
         """
@@ -439,7 +437,6 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
         positions_tensor : tf.Tensor
 
         """
-
         # Compute the number of atoms and configurations in the batch.
         atoms_per_batch, batch_size, _ = tf.shape(atoms)
 
@@ -505,7 +502,8 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
             for name in self.key_list
         }
         indices = tf.transpose(indices)
-
+        print(self.particles_list)
+        print(self.index_list)
         particles_list = self.particles_list
         for tuples in itertools.combinations_with_replacement(self.index_list, 2):
             names = self._get_species_names(tuples)

--- a/mdsuite/calculators/radial_distribution_function.py
+++ b/mdsuite/calculators/radial_distribution_function.py
@@ -506,7 +506,7 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
         particles_list = self.particles_list
         for tuples in itertools.combinations_with_replacement(self.index_list, 2):
             names = self._get_species_names(tuples)
-            start_ = tf.concat(
+            start_ = tf.stack(
                 [
                     sum(particles_list[: tuples[0]]) - start_batch,
                     sum(particles_list[: tuples[1]]),

--- a/mdsuite/calculators/radial_distribution_function.py
+++ b/mdsuite/calculators/radial_distribution_function.py
@@ -502,8 +502,7 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
             for name in self.key_list
         }
         indices = tf.transpose(indices)
-        print(self.particles_list)
-        print(self.index_list)
+
         particles_list = self.particles_list
         for tuples in itertools.combinations_with_replacement(self.index_list, 2):
             names = self._get_species_names(tuples)

--- a/mdsuite/calculators/trajectory_calculator.py
+++ b/mdsuite/calculators/trajectory_calculator.py
@@ -266,7 +266,7 @@ class TrajectoryCalculator(Calculator, ABC):
             self.batch_size,
             self.n_batches,
             self.remainder,
-        ) = self.memory_manager.get_batch_size(system=self.system_property)
+        ) = self.memory_manager.get_batch_size()
 
         self.ensemble_loop, self.minibatch = self.memory_manager.get_ensemble_loop(
             self.args.data_range, self.args.correlation_time
@@ -281,7 +281,6 @@ class TrajectoryCalculator(Calculator, ABC):
 
         if correct:
             self._correct_batch_properties()
-
         self.data_manager = DataManager(
             data_path=data_path,
             database=self.database,

--- a/mdsuite/calculators/trajectory_calculator.py
+++ b/mdsuite/calculators/trajectory_calculator.py
@@ -267,7 +267,6 @@ class TrajectoryCalculator(Calculator, ABC):
             self.n_batches,
             self.remainder,
         ) = self.memory_manager.get_batch_size()
-
         self.ensemble_loop, self.minibatch = self.memory_manager.get_ensemble_loop(
             self.args.data_range, self.args.correlation_time
         )

--- a/mdsuite/calculators/trajectory_calculator.py
+++ b/mdsuite/calculators/trajectory_calculator.py
@@ -344,7 +344,6 @@ class TrajectoryCalculator(Calculator, ABC):
         """
         path_list = [join_path(item, self.loaded_property.name) for item in subject_list]
         self._prepare_managers(path_list, correct=correct)
-
         type_spec = {}
         for item in subject_list:
             dict_ref = "/".join([item, self.loaded_property.name])

--- a/mdsuite/memory_management/memory_manager.py
+++ b/mdsuite/memory_management/memory_manager.py
@@ -175,19 +175,13 @@ class MemoryManager:
 
         return scale_function, scale_function_parameters
 
-    def get_batch_size(self, system: bool = False) -> tuple:
+    def get_batch_size(self) -> tuple:
         """
         Calculate the batch size of an operation.
 
         This method takes the tensor_values requirements of an operation and returns
         how big each batch of tensor_values should be for such an operation.
 
-
-        Parameters
-        ----------
-        system : bool
-                Tell the database what kind of tensor_values it is looking at,
-                atomistic, or system wide.
         Returns
         -------
         batch_size : int
@@ -200,7 +194,6 @@ class MemoryManager:
         """
         if self.data_path is None:
             raise ValueError("No tensor_values have been requested.")
-
         per_configuration_memory: float = 0.0
         for item in self.data_path:
             n_particles, n_configs, n_bytes = self.database.get_data_size(item)


### PR DESCRIPTION
Using #563 I am trying to fix GitHub CI jobs that seem to fail in minibatch limits

* Found that the latest TensorFlow release doesn't like using concat on scalars so this has been changed to stack.
* The Einstein averaging for remainder case was also wrong but this is fixed now and local testing demonstrated that it works.
* I could test the atomwise batching and it worked great! 

We should consider how best to add low memory cases. We can run all of the tests in a memory_fraction=0.9 and then a memory_fraction=0.01 and that should test all cases. @christophlohrmann @PythonFZ what do you think? It should probably come in a different PR once we decide on the best format for duplicating tests only with one configuration parameter changing