### PR TITLE
Python fz add dataset keys

### DIFF
--- a/CI/unit_tests/project/test_project_add_experiment.py
+++ b/CI/unit_tests/project/test_project_add_experiment.py
@@ -258,7 +258,7 @@ def test_lammpsflux_read(traj_files, tmp_path):
         "NaCl_flux", simulation_data=file_reader, timestep=0.1, temperature=1600
     )
     pressures = project.experiments["NaCl_flux"].load_matrix(
-        species=["Observables"], property_name="Pressure"
+        species=[mds.utils.DatasetKeys.OBSERVABLES], property_name="Pressure"
     )
     # check one value from the file
     # line 87

--- a/CI/unit_tests/transformations/test_transformator_parent.py
+++ b/CI/unit_tests/transformations/test_transformator_parent.py
@@ -166,7 +166,9 @@ def test_save_to_correct_name(tmp_path):
         output_property=PropertyInfo(name="test_multi", n_dims=2),
     )
     exp.cls_transformation_run(trafo2)
-    ret2 = exp.load_matrix(species=["Observables"], property_name="test_multi")
+    ret2 = exp.load_matrix(
+        species=[mds.utils.DatasetKeys.OBSERVABLES], property_name="test_multi"
+    )
     assert isinstance(ret2, dict)
 
 

--- a/CI/unit_tests/utils/test_constants.py
+++ b/CI/unit_tests/utils/test_constants.py
@@ -1,0 +1,12 @@
+"""Test for MDSuite utils.constants."""
+import dataclasses
+
+import pytest
+
+import mdsuite as mds
+
+
+def test_DatasetKeys():
+    assert mds.utils.DatasetKeys.OBSERVABLES == "Observables"
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        mds.utils.DatasetKeys.OBSERVABLES = None

--- a/mdsuite/calculators/einstein_helfand_ionic_conductivity.py
+++ b/mdsuite/calculators/einstein_helfand_ionic_conductivity.py
@@ -35,6 +35,7 @@ from tqdm import tqdm
 from mdsuite.calculators.calculator import call
 from mdsuite.calculators.trajectory_calculator import TrajectoryCalculator
 from mdsuite.database.mdsuite_properties import mdsuite_properties
+from mdsuite.utils import DatasetKeys
 from mdsuite.utils.calculator_helper_methods import fit_einstein_curve
 from mdsuite.utils.units import boltzmann_constant, elementary_charge
 
@@ -213,9 +214,11 @@ class EinsteinHelfandIonicConductivity(TrajectoryCalculator, ABC):
         # Compute the pre-factor early.
         self._calculate_prefactor()
 
-        dict_ref = str.encode("/".join(["Observables", self.loaded_property.name]))
+        dict_ref = str.encode(
+            "/".join([DatasetKeys.OBSERVABLES, self.loaded_property.name])
+        )
 
-        batch_ds = self.get_batch_dataset(["Observables"])
+        batch_ds = self.get_batch_dataset([DatasetKeys.OBSERVABLES])
 
         for batch in tqdm(
             batch_ds,
@@ -223,7 +226,7 @@ class EinsteinHelfandIonicConductivity(TrajectoryCalculator, ABC):
             total=self.n_batches,
             disable=self.memory_manager.minibatch,
         ):
-            ensemble_ds = self.get_ensemble_dataset(batch, "Observables")
+            ensemble_ds = self.get_ensemble_dataset(batch, DatasetKeys.OBSERVABLES)
 
             for ensemble in ensemble_ds:
                 self.ensemble_operation(ensemble[dict_ref])

--- a/mdsuite/calculators/einstein_helfand_thermal_conductivity.py
+++ b/mdsuite/calculators/einstein_helfand_thermal_conductivity.py
@@ -35,6 +35,7 @@ from tqdm import tqdm
 from mdsuite.calculators.calculator import call
 from mdsuite.calculators.trajectory_calculator import TrajectoryCalculator
 from mdsuite.database.mdsuite_properties import mdsuite_properties
+from mdsuite.utils import DatasetKeys
 from mdsuite.utils.calculator_helper_methods import fit_einstein_curve
 
 
@@ -238,9 +239,11 @@ class EinsteinHelfandThermalConductivity(TrajectoryCalculator, ABC):
         # Compute the pre-factor early.
         self._calculate_prefactor()
 
-        dict_ref = str.encode("/".join(["Observables", self.loaded_property.name]))
+        dict_ref = str.encode(
+            "/".join([DatasetKeys.OBSERVABLES, self.loaded_property.name])
+        )
 
-        batch_ds = self.get_batch_dataset(["Observables"])
+        batch_ds = self.get_batch_dataset([DatasetKeys.OBSERVABLES])
 
         for batch in tqdm(
             batch_ds,
@@ -248,7 +251,7 @@ class EinsteinHelfandThermalConductivity(TrajectoryCalculator, ABC):
             total=self.n_batches,
             disable=self.memory_manager.minibatch,
         ):
-            ensemble_ds = self.get_ensemble_dataset(batch, "Observables")
+            ensemble_ds = self.get_ensemble_dataset(batch, DatasetKeys.OBSERVABLES)
 
             for ensemble in ensemble_ds:
                 self.ensemble_operation(ensemble[dict_ref])

--- a/mdsuite/calculators/einstein_helfand_thermal_kinaci.py
+++ b/mdsuite/calculators/einstein_helfand_thermal_kinaci.py
@@ -36,6 +36,7 @@ from tqdm import tqdm
 from mdsuite.calculators.calculator import call
 from mdsuite.calculators.trajectory_calculator import TrajectoryCalculator
 from mdsuite.database.mdsuite_properties import mdsuite_properties
+from mdsuite.utils import DatasetKeys
 from mdsuite.utils.calculator_helper_methods import fit_einstein_curve
 
 
@@ -244,9 +245,11 @@ class EinsteinHelfandThermalKinaci(TrajectoryCalculator, ABC):
         # Compute the pre-factor early.
         self._calculate_prefactor()
 
-        dict_ref = str.encode("/".join(["Observables", self.loaded_property.name]))
+        dict_ref = str.encode(
+            "/".join([DatasetKeys.OBSERVABLES, self.loaded_property.name])
+        )
 
-        batch_ds = self.get_batch_dataset(["Observables"])
+        batch_ds = self.get_batch_dataset([DatasetKeys.OBSERVABLES])
 
         for batch in tqdm(
             batch_ds,
@@ -254,7 +257,7 @@ class EinsteinHelfandThermalKinaci(TrajectoryCalculator, ABC):
             total=self.n_batches,
             disable=self.memory_manager.minibatch,
         ):
-            ensemble_ds = self.get_ensemble_dataset(batch, "Observables")
+            ensemble_ds = self.get_ensemble_dataset(batch, DatasetKeys.OBSERVABLES)
 
             for ensemble in ensemble_ds:
                 self.ensemble_operation(ensemble[dict_ref])

--- a/mdsuite/calculators/green_kubo_ionic_conductivity.py
+++ b/mdsuite/calculators/green_kubo_ionic_conductivity.py
@@ -43,6 +43,7 @@ from tqdm import tqdm
 from mdsuite.calculators.calculator import call
 from mdsuite.calculators.trajectory_calculator import TrajectoryCalculator
 from mdsuite.database.mdsuite_properties import mdsuite_properties
+from mdsuite.utils import DatasetKeys
 from mdsuite.utils.units import boltzmann_constant, elementary_charge
 
 
@@ -288,17 +289,19 @@ class GreenKuboIonicConductivity(TrajectoryCalculator, ABC):
         # Compute the pre-factor early.
         self._calculate_prefactor()
 
-        dict_ref = str.encode("/".join(["Observables", self.loaded_property.name]))
+        dict_ref = str.encode(
+            "/".join([DatasetKeys.OBSERVABLES, self.loaded_property.name])
+        )
         self.count = 0
         self.acf_array = np.zeros((self.args.data_range,))
-        batch_ds = self.get_batch_dataset(["Observables"])
+        batch_ds = self.get_batch_dataset([DatasetKeys.OBSERVABLES])
         for batch in tqdm(
             batch_ds,
             ncols=70,
             total=self.n_batches,
             disable=self.memory_manager.minibatch,
         ):
-            ensemble_ds = self.get_ensemble_dataset(batch, "Observables")
+            ensemble_ds = self.get_ensemble_dataset(batch, DatasetKeys.OBSERVABLES)
             for ensemble in ensemble_ds:
                 self.acf_array += self.ensemble_operation(ensemble[dict_ref])
                 self.count += 1

--- a/mdsuite/calculators/green_kubo_thermal_conductivity.py
+++ b/mdsuite/calculators/green_kubo_thermal_conductivity.py
@@ -38,6 +38,7 @@ from tqdm import tqdm
 from mdsuite.calculators.calculator import call
 from mdsuite.calculators.trajectory_calculator import TrajectoryCalculator
 from mdsuite.database.mdsuite_properties import mdsuite_properties
+from mdsuite.utils import DatasetKeys
 
 
 @dataclass
@@ -258,9 +259,11 @@ class GreenKuboThermalConductivity(TrajectoryCalculator, ABC):
         # Compute the pre-factor early.
         self._calculate_prefactor()
 
-        dict_ref = str.encode("/".join(["Observables", self.loaded_property.name]))
+        dict_ref = str.encode(
+            "/".join([DatasetKeys.OBSERVABLES, self.loaded_property.name])
+        )
 
-        batch_ds = self.get_batch_dataset(["Observables"])
+        batch_ds = self.get_batch_dataset([DatasetKeys.OBSERVABLES])
 
         for batch in tqdm(
             batch_ds,
@@ -268,7 +271,7 @@ class GreenKuboThermalConductivity(TrajectoryCalculator, ABC):
             total=self.n_batches,
             disable=self.memory_manager.minibatch,
         ):
-            ensemble_ds = self.get_ensemble_dataset(batch, "Observables")
+            ensemble_ds = self.get_ensemble_dataset(batch, DatasetKeys.OBSERVABLES)
 
             for ensemble in ensemble_ds:
                 self.ensemble_operation(ensemble[dict_ref])

--- a/mdsuite/calculators/green_kubo_viscosity.py
+++ b/mdsuite/calculators/green_kubo_viscosity.py
@@ -38,6 +38,7 @@ from tqdm import tqdm
 from mdsuite.calculators.calculator import call
 from mdsuite.calculators.trajectory_calculator import TrajectoryCalculator
 from mdsuite.database.mdsuite_properties import mdsuite_properties
+from mdsuite.utils import DatasetKeys
 
 
 @dataclass
@@ -252,9 +253,11 @@ class GreenKuboViscosity(TrajectoryCalculator, ABC):
         # Compute the pre-factor early.
         self._calculate_prefactor()
 
-        dict_ref = str.encode("/".join(["Observables", self.loaded_property.name]))
+        dict_ref = str.encode(
+            "/".join([DatasetKeys.OBSERVABLES, self.loaded_property.name])
+        )
 
-        batch_ds = self.get_batch_dataset(["Observables"])
+        batch_ds = self.get_batch_dataset([DatasetKeys.OBSERVABLES])
 
         for batch in tqdm(
             batch_ds,
@@ -262,7 +265,7 @@ class GreenKuboViscosity(TrajectoryCalculator, ABC):
             total=self.n_batches,
             disable=self.memory_manager.minibatch,
         ):
-            ensemble_ds = self.get_ensemble_dataset(batch, "Observables")
+            ensemble_ds = self.get_ensemble_dataset(batch, DatasetKeys.OBSERVABLES)
 
             for ensemble in ensemble_ds:
                 self.ensemble_operation(ensemble[dict_ref])

--- a/mdsuite/calculators/green_kubo_viscosity_flux.py
+++ b/mdsuite/calculators/green_kubo_viscosity_flux.py
@@ -38,6 +38,7 @@ from tqdm import tqdm
 from mdsuite.calculators.calculator import call
 from mdsuite.calculators.trajectory_calculator import TrajectoryCalculator
 from mdsuite.database.mdsuite_properties import mdsuite_properties
+from mdsuite.utils import DatasetKeys
 
 
 @dataclass
@@ -250,9 +251,11 @@ class GreenKuboViscosityFlux(TrajectoryCalculator, ABC):
         # Compute the pre-factor early.
         self._calculate_prefactor()
 
-        dict_ref = str.encode("/".join(["Observables", self.loaded_property.name]))
+        dict_ref = str.encode(
+            "/".join([DatasetKeys.OBSERVABLES, self.loaded_property.name])
+        )
 
-        batch_ds = self.get_batch_dataset(["Observables"])
+        batch_ds = self.get_batch_dataset([DatasetKeys.OBSERVABLES])
 
         for batch in tqdm(
             batch_ds,
@@ -260,7 +263,7 @@ class GreenKuboViscosityFlux(TrajectoryCalculator, ABC):
             total=self.n_batches,
             disable=self.memory_manager.minibatch,
         ):
-            ensemble_ds = self.get_ensemble_dataset(batch, "Observables")
+            ensemble_ds = self.get_ensemble_dataset(batch, DatasetKeys.OBSERVABLES)
 
             for ensemble in ensemble_ds:
                 self.ensemble_operation(ensemble[dict_ref])

--- a/mdsuite/calculators/radial_distribution_function.py
+++ b/mdsuite/calculators/radial_distribution_function.py
@@ -718,8 +718,7 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
 
     @property
     def ideal_correction(self) -> float:
-        """
-        Get the correct ideal gas term.
+        """Get the correct ideal gas term.
 
         In the case of a cutoff value greater than half of the box size, the ideal gas
         term of the experiment must be corrected due to the lack of spherical symmetry
@@ -730,8 +729,8 @@ class RadialDistributionFunction(TrajectoryCalculator, ABC):
         correction : float
                 Correct ideal gas term for the RDF prefactor
         """
-        # TODO make it a property
-        def _spherical_symmetry(data: np.array) -> np.array:
+
+        def _spherical_symmetry(data: np.array) -> np.array:  # TODO make it a property
             """
             Operation to perform for full spherical symmetry.
 

--- a/mdsuite/file_io/lammps_flux_files.py
+++ b/mdsuite/file_io/lammps_flux_files.py
@@ -36,6 +36,7 @@ from mdsuite.file_io.lammps_trajectory_files import extract_properties_from_head
 from mdsuite.file_io.tabular_text_files import (
     get_species_list_from_tabular_text_reader_data,
 )
+from mdsuite.utils import DatasetKeys
 
 column_names = {
     mdsuite_properties.temperature: ["temp"],
@@ -126,7 +127,7 @@ class LAMMPSFluxFile(mdsuite.file_io.tabular_text_files.TabularTextFileProcessor
                     column_header.split(), self._column_name_dict
                 )
 
-            species_dict = {"Observables": [0]}
+            species_dict = {DatasetKeys.OBSERVABLES: [0]}
             return mdsuite.file_io.tabular_text_files.TabularTextFileReaderMData(
                 n_configs=n_steps,
                 species_name_to_line_idx_dict=species_dict,

--- a/mdsuite/transformations/transformations.py
+++ b/mdsuite/transformations/transformations.py
@@ -44,6 +44,7 @@ import mdsuite.database.simulation_database
 from mdsuite.database.data_manager import DataManager
 from mdsuite.database.simulation_database import Database
 from mdsuite.memory_management.memory_manager import MemoryManager
+from mdsuite.utils import DatasetKeys
 from mdsuite.utils.meta_functions import join_path
 
 if TYPE_CHECKING:
@@ -287,7 +288,7 @@ class Transformations:
         """
         if system_tensor:
             output_length = 1
-            path = join_path("Observables", self.output_property.name)
+            path = join_path(DatasetKeys.OBSERVABLES, self.output_property.name)
         else:
             try:
                 output_length = self.experiment.species[species].n_particles

--- a/mdsuite/utils/__init__.py
+++ b/mdsuite/utils/__init__.py
@@ -28,6 +28,7 @@ Summary
 from mdsuite.utils import helpers
 from mdsuite.utils.colours import Colour
 from mdsuite.utils.config import config
+from mdsuite.utils.constants import DatasetKeys
 from mdsuite.utils.units import Units
 
-__all__ = ["config", "Units", "Colour", "helpers"]
+__all__ = ["config", "Units", "Colour", "helpers", "DatasetKeys"]

--- a/mdsuite/utils/constants.py
+++ b/mdsuite/utils/constants.py
@@ -24,3 +24,15 @@ If you use this module please cite us with:
 Summary
 -------
 """
+import dataclasses
+
+
+class _FrozenCls(type):
+    def __setattr__(cls, name, value):
+        raise dataclasses.FrozenInstanceError(f"cannot assign to attribute '{name}'")
+
+
+class DatasetKeys(metaclass=_FrozenCls):
+    """Class to hold the keys for the datasets."""
+
+    OBSERVABLES = "Observables"


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Add the following to avoid using the string `"Observables"` everywhere.
```python
class DatasetKeys(metaclass=_FrozenCls):
    """Class to hold the keys for the datasets."""

    OBSERVABLES = "Observables"
```
