### PR TITLE
Allow for new groups to be added after DS creation.

### DIFF
--- a/CI/unit_tests/database/test_simulation_database.py
+++ b/CI/unit_tests/database/test_simulation_database.py
@@ -74,7 +74,7 @@ class TestScalingFunctions(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory()
         os.chdir(temp_dir.name)
         database = Database()
-        database.add_dataset({"Na": {"Forces": (200, 5000, 3)}})
+        database.initialize_database({"Na": {"Forces": (200, 5000, 3)}})
         with hf.File("database") as db:
             keys_top = list(db.keys())
             keys_bottom = list(db[keys_top[0]])
@@ -97,7 +97,7 @@ class TestScalingFunctions(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory()
         os.chdir(temp_dir.name)
         database = Database()
-        database.add_dataset({"Na": {"Forces": (200, 5000, 3)}})
+        database.initialize_database({"Na": {"Forces": (200, 5000, 3)}})
         database.resize_datasets({"Na": {"Forces": (200, 300, 3)}})
 
         with hf.File("database") as db:
@@ -123,7 +123,7 @@ class TestScalingFunctions(unittest.TestCase):
         os.chdir(temp_dir.name)
         database = Database()
         assert not database.database_exists()
-        database.add_dataset({"Na": {"Forces": (200, 5000, 3)}})
+        database.initialize_database({"Na": {"Forces": (200, 5000, 3)}})
         assert database.database_exists()
         os.chdir("..")
         temp_dir.cleanup()
@@ -139,7 +139,7 @@ class TestScalingFunctions(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory()
         os.chdir(temp_dir.name)
         database = Database()
-        database.add_dataset({"Na": {"Forces": (200, 5000, 3)}})
+        database.initialize_database({"Na": {"Forces": (200, 5000, 3)}})
         assert not database.check_existence("Na/Positions")
         assert database.check_existence("Na/Forces")
         os.chdir("..")

--- a/CI/unit_tests/project/test_project_add_experiment.py
+++ b/CI/unit_tests/project/test_project_add_experiment.py
@@ -155,7 +155,6 @@ def test_add_new_groups(traj_files, tmp_path):
         old_shape = db["Na"]["Positions"].shape
 
     exp.add_data(traj_files["NaCl_gk_i_q.lammpstraj"])
-
     with hf.File("MDSuite_Project/NaCl/database.hdf5") as db:
         assert list(db["Na"].keys()) == [
             "Box_Images",
@@ -168,6 +167,10 @@ def test_add_new_groups(traj_files, tmp_path):
         assert new_shape[1] == 2 * old_shape[1]
 
         assert db["Na"]["Charge"].shape == (500, 501, 1)  # Should be old shape
+
+        # Ensure data is actually added
+        assert np.sum(db["Cl"]["Charge"][:]) / (500 * 501) == -1
+        assert np.sum(db["Na"]["Charge"][:]) / (500 * 501) == 1
 
     assert list(project.experiments) == ["NaCl"]
 

--- a/mdsuite/database/simulation_database.py
+++ b/mdsuite/database/simulation_database.py
@@ -350,22 +350,24 @@ class Database:
                     write_data = chunk_data[sp_info.name][prop_info.name]
 
                     dataset_shape = database[dataset_name].shape
-                    start_idx = database[dataset_name].attrs["starting_index"]
-                    stop_index = start_idx + chunk.chunk_size
+                    start_index = database[dataset_name].attrs["starting_index"]
+                    stop_index = start_index + chunk.chunk_size
 
                     if len(dataset_shape) == 2:
                         # only one particle
-                        database[dataset_name][start_idx:stop_index, :] = write_data[
+                        database[dataset_name][start_index:stop_index, :] = write_data[
                             :, 0, :
                         ]
 
                     elif len(dataset_shape) == 3:
                         if workaround_time_in_axis_1:
                             database[dataset_name][
-                                :, start_idx:stop_index, :
+                                :, start_index:stop_index, :
                             ] = np.swapaxes(write_data, 0, 1)
                         else:
-                            database[dataset_name][start_idx:stop_index, ...] = write_data
+                            database[dataset_name][
+                                start_index:stop_index, ...
+                            ] = write_data
                     else:
                         raise ValueError(
                             "dataset shape must be either (n_part,n_config,n_dim) or"
@@ -403,10 +405,10 @@ class Database:
                 try:
                     if len(dataset_information[:-1]) == 1:
                         axis = 0
-                        expansion = dataset_information[0] + db[identifier].shape[0]
+                        expansion = dataset_information[axis] + db[identifier].shape[axis]
                     else:
                         axis = 1
-                        expansion = dataset_information[1] + db[identifier].shape[1]
+                        expansion = dataset_information[axis] + db[identifier].shape[axis]
 
                     db[identifier].resize(expansion, axis)
 

--- a/mdsuite/database/simulation_database.py
+++ b/mdsuite/database/simulation_database.py
@@ -405,11 +405,10 @@ class Database:
                 try:
                     if len(dataset_information[:-1]) == 1:
                         axis = 0
-                        expansion = dataset_information[axis] + db[identifier].shape[axis]
                     else:
                         axis = 1
-                        expansion = dataset_information[axis] + db[identifier].shape[axis]
 
+                    expansion = dataset_information[axis] + db[identifier].shape[axis]
                     db[identifier].resize(expansion, axis)
 
                 # It is actually a new group

--- a/mdsuite/experiment/experiment.py
+++ b/mdsuite/experiment/experiment.py
@@ -541,7 +541,7 @@ class Experiment(ExperimentDatabase):
             database.resize_datasets(architecture)
 
         for i, batch in enumerate(file_processor.get_configurations_generator()):
-            database.add_data(chunk=batch, start_idx=self.number_of_configurations)
+            database.add_data(chunk=batch)
             self.number_of_configurations += batch.chunk_size
 
         self.version += 1

--- a/mdsuite/file_io/chemfiles_read.py
+++ b/mdsuite/file_io/chemfiles_read.py
@@ -138,7 +138,9 @@ class ChemfilesRead(mdsuite.file_io.file_read.FileProcessor):
         self, traj: chemfiles.Trajectory, n_configs: int
     ) -> mdsuite.database.simulation_database.TrajectoryChunkData:
         """
-        Read n configurations and package them into a trajectory chunk of the right format
+        Read n configurations and package them into a trajectory chunk of the
+        right format.
+
         Parameters
         ----------
         traj : chemfiles.Trajectory

--- a/mdsuite/transformations/transformations.py
+++ b/mdsuite/transformations/transformations.py
@@ -226,7 +226,7 @@ class Transformations:
         )
 
         try:
-            self.database.add_data(chunk=chunk, start_idx=index + self.offset)
+            self.database.add_data(chunk=chunk)
         except OSError:
             """
             This is used because in Windows and in WSL we got the error that
@@ -234,7 +234,7 @@ class Transformations:
             wait, and we add again.
             """
             time.sleep(0.5)
-            self.database.add_data(chunk=chunk, start_idx=index + self.offset)
+            self.database.add_data(chunk=chunk)
 
     def _prepare_monitors(self, data_path: Union[list, np.array]):
         """


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #570 


#### Summary of additions and changes

* Check if a group in the new data is different and add it to the database if so
* Added a test to check that it is working

## TODO

- [x] Add starting configuration check

~~The next problem comes in actually adding the data.~~

```python
for i, batch in enumerate(file_processor.get_configurations_generator()):
    database.add_data(chunk=batch, start_idx=self.number_of_configurations)
    self.number_of_configurations += batch.chunk_size
```
~~This code takes the first location in the database to be the current number of configurations. For some groups this will be different now. @christophlohrmann Some ideas for approaching this would be awesome.~~

I will try to store the last index as a dataset attribute making the need for passing the starting index redundant. It would also give us a clever way to over-write data.

This is resolved now and the PR is ready so long as tests are passing